### PR TITLE
Download command returns list of asset file names

### DIFF
--- a/lib/shop_sync/authentication.rb
+++ b/lib/shop_sync/authentication.rb
@@ -17,13 +17,13 @@ module ShopSync
       end
 
       def get(store)
+        auth = {}
         File.open(get_store_env_path(store), "r") do |f|
-          key = f.gets.split('=')[1]
-          password = f.gets.split('=')[1]
-          host = f.gets.split('=')[1]
+          auth[:key]      = f.gets.split('=')[1].strip!
+          auth[:password] = f.gets.split('=')[1].strip!
+          auth[:host]     = f.gets.split('=')[1].strip!
         end
-
-        [key, password, host]
+        auth
       end
 
       def clear(store)

--- a/lib/shop_sync/cli.rb
+++ b/lib/shop_sync/cli.rb
@@ -1,5 +1,6 @@
 require 'thor'
 require 'fileutils'
+require 'shopify_api'
 
 module ShopSync
   class CLI < Thor
@@ -29,7 +30,19 @@ module ShopSync
 
     desc "download STORE", "Download the theme assets into the current directory for the configured STORE"
     def download store
+      unless Authentication.authenticated?(store)
+        puts "Either the store doesn't exist or you haven't authenticated"
+      else
+        auths = Authentication.get(store)
+      end
 
+      shop_url = "https://#{auths[:key]}:#{auths[:password]}@#{auths[:host]}/admin"
+
+      ShopifyAPI::Base.site = shop_url
+      assets = ShopifyAPI::Asset.all
+      assets.each do |asset|
+        puts asset.public_url  
+      end
     end
 
     desc "replace STORE", "Replace the theme assets from the current directory to the configured STORE"

--- a/test/lib/shop_sync/authentication_test.rb
+++ b/test/lib/shop_sync/authentication_test.rb
@@ -1,0 +1,7 @@
+require_relative '../../minitest_helper'
+
+class TestEvent < Minitest::Test
+  def test_authentication
+    assert false
+  end
+end


### PR DESCRIPTION
Worked with @enriquez to fix a bug in Authentication and get started on the `download` command.
